### PR TITLE
[#157] Updates the banner on the 2.01 site

### DIFF
--- a/iatistandard/_templates/layout_dev.html
+++ b/iatistandard/_templates/layout_dev.html
@@ -1,10 +1,8 @@
 {% extends "layout_base.html" %}
 {% block site_notice %}
-    {% if version == '2.01' %}
-         <div id="site-notice" style="background-color: rgb(255, 245, 0);"><strong>This is version 2.01 of the IATI Standard. This version has been released but is not live (<a href="/201/upgrades/all-versions/">more info</a>). <a href="/201/upgrades/all-versions/">See other versions</a>.</strong></div>.
-    {% else %}
+   
          <div id="site-notice" style="background-color: red"><strong>This is a development version of version {{version}} of the IATI Standard. <a href="/upgrades/all-versions/">See other versions</a>.</strong></div>
-    {% endif %}
+ 
 {% endblock %}
 {% block extra_scripts %}
     <script>

--- a/iatistandard/_templates/layout_live.html
+++ b/iatistandard/_templates/layout_live.html
@@ -1,6 +1,6 @@
 {% extends "layout_base.html" %}
 {% block site_notice %}
-    <div id="site-notice"><strong>This is version {{version}} of the IATI Standard. Find out about <a href="http://dev.iatistandard.org/201/">version 2.01</a>. <a href="/upgrades/all-versions/">See other versions</a>.</strong></div>
+    <div id="site-notice"><strong>This is version {{version}} of the IATI Standard. <a href="201/upgrades/all-versions/">See other versions</a>.</strong></div>
 {% endblock %}
 {% block extra_scripts %}
     <script type="text/javascript">


### PR DESCRIPTION
This makes the links in the banner go to the right place
Also turns the dev site banner back to a 'this is a dev site' version
This commit should be merged on 6th Jan 2015