### PR TITLE
[#144] Adds a redirect as requested

### DIFF
--- a/iatistandard/redirects.conf
+++ b/iatistandard/redirects.conf
@@ -261,7 +261,7 @@ redirect 301 /codelists/repayment-nopa. /codelists/LoanRepaymentPeriod
 
 # New organisation identifiers page https://github.com/IATI/IATI-Websites/issues/103
 redirect 301 /org-ref /organisation-identifiers
-redirect 301 getting-started/organisation-data/organisation-identifiers /organisation-identifiers
+redirect 301 /getting-started/organisation-data/organisation-identifiers /organisation-identifiers
 
 redirect 301 /getting-started /how-to-publish
 redirect 301 /schema/sample-activity-xml /activity-standard/example-xml

--- a/iatistandard/redirects.conf
+++ b/iatistandard/redirects.conf
@@ -261,6 +261,7 @@ redirect 301 /codelists/repayment-nopa. /codelists/LoanRepaymentPeriod
 
 # New organisation identifiers page https://github.com/IATI/IATI-Websites/issues/103
 redirect 301 /org-ref /organisation-identifiers
+redirect 301 getting-started/organisation-data/organisation-identifiers /organisation-identifiers
 
 redirect 301 /getting-started /how-to-publish
 redirect 301 /schema/sample-activity-xml /activity-standard/example-xml


### PR DESCRIPTION
The ticket is to redirect
/getting-started/organisation-data/organisation-identifiers/
to
/organisation-identifiers

I think this commit will do that, by placing it above line 266
and not interfere with outher getting-started redirects.

Please check.