### PR TITLE
[#163] Fixes 3 broken links to guidance/how-to-publish

### DIFF
--- a/iatistandard/_templates/layout_base.html
+++ b/iatistandard/_templates/layout_base.html
@@ -256,9 +256,9 @@
         <ul>
  <li><a title="Introduction" href="introduction/">Introduction</a></li>        
 <li><a title="Key Considerations" href="key-considerations/">Key Considerations</a></li> 
-<li><a title="Preparing your organisation" href="how-to-publish/prepare-your-org/">Preparing your organisation</a></li>
-<li><a title="Tools" href="how-to-publish/select-publishing-tool/">Publishing tools</a></li>            
-<li><a title="Updating IATI data" href="how-to-publish/regular-updates/">Updating IATI data</a></li>
+<li><a title="Preparing your organisation" href="guidance/how-to-publish/prepare-your-org/">Preparing your organisation</a></li>
+<li><a title="Tools" href="guidance/how-to-publish/select-publishing-tool/">Publishing tools</a></li>            
+<li><a title="Updating IATI data" href="guidance/how-to-publish/regular-updates/">Updating IATI data</a></li>
         </ul>
             </div>
             <div class="icon detail">

--- a/iatistandard/root/index.html
+++ b/iatistandard/root/index.html
@@ -114,9 +114,9 @@
         <ul>
  <li><a title="Introduction" href="201/introduction/">Introduction</a></li>        
 <li><a title="Key Considerations" href="201/key-considerations/">Key Considerations</a></li> 
-<li><a title="Preparing your organisation" href="201/how-to-publish/prepare-your-org/">Preparing your organisation</a></li>
-<li><a title="Tools" href="201/how-to-publish/select-publishing-tool/">Publishing tools</a></li>            
-<li><a title="Updating IATI data" href="201/how-to-publish/regular-updates/">Updating IATI data</a></li>
+<li><a title="Preparing your organisation" href="201/guidance/how-to-publish/prepare-your-org/">Preparing your organisation</a></li>
+<li><a title="Tools" href="201/guidance/how-to-publish/select-publishing-tool/">Publishing tools</a></li>            
+<li><a title="Updating IATI data" href="201/guidance/how-to-publish/regular-updates/">Updating IATI data</a></li>
         </ul>
             </div>
             <div class="icon detail">


### PR DESCRIPTION
Partial fix - only fixes the index page at the root of the site. 

Need to fix 1.05 index page as well