### PR TITLE
Remove reference to 1.05

### DIFF
--- a/iatistandard/root/index.html
+++ b/iatistandard/root/index.html
@@ -6,7 +6,7 @@
 <head>
 <meta charset="UTF-8" />
     <title>Home | The IATI Standard</title>
-    <link rel="top" title="IATI Standard 1.05 documentation" href="#" /> 
+    <link rel="top" title="IATI Standard Documentation" href="#" /> 
 
 <!--[if lt IE 9]>
 <script src="_static/html5.js" type="text/javascript"></script>


### PR DESCRIPTION
Remove a reference to 1.05 that exists on this page for all versions of the Standard, whether 1.05 or not.