### PR TITLE
Remove 2.02 release notice

### DIFF
--- a/iatistandard/_templates/layout_live.html
+++ b/iatistandard/_templates/layout_live.html
@@ -1,6 +1,6 @@
 {% extends "layout_base.html" %}
 {% block site_notice %}
-    <div id="site-notice"><strong>This is version {{version}} of the IATI Standard. <a href="/202/upgrades/all-versions/">See other versions</a>.</strong><br/>A <a href="/201/upgrades/decimal-upgrade-to-2-02/">new version (v2.02) became live in December 2015</a>.</div>
+    <div id="site-notice"><strong>This is version {{version}} of the IATI Standard. <a href="/upgrades/all-versions/">See other versions</a>.</strong></div>
 {% endblock %}
 {% block extra_scripts %}
     <script type="text/javascript">


### PR DESCRIPTION
With 2.03 releasing, there does not need to be a notification of when 2.02 released.

This notification is being removed entirely since the `Upgrades` section contains this information for those who are interested. Other people should not need to know this information.