### PR TITLE
Make homepage links version independant

### DIFF
--- a/iatistandard/root/index.html
+++ b/iatistandard/root/index.html
@@ -6,7 +6,7 @@
 <head>
 <meta charset="UTF-8" />
     <title>Home | The IATI Standard</title>
-    <link rel="top" title="IATI Standard Documentation" href="#" /> 
+    <link rel="top" title="IATI Standard Documentation" href="#" />
 
 <!--[if lt IE 9]>
 <script src="_static/html5.js" type="text/javascript"></script>
@@ -38,8 +38,8 @@
     <body class="home page page-template page-template-template-home-page-php single-author singular two-column left-sidebar">
 
 <a id="top"></a>
-    
-    <div id="site-notice"><strong><a href="202/upgrades/all-versions/">Select a Version</a></strong></div>
+
+    <div id="site-notice"><strong><a href="upgrades/all-versions/">Select a Version</a></strong></div>
 
     <div id="page" class="hfeed">
     <header id="header" role="banner">
@@ -80,7 +80,7 @@
     <li class="menu-item menu-item-type-post_type menu-item-object-page ">
         <a href="developer/">Developers</a>
     </li>-->
-   
+
     <li class="menu-item menu-item-type-post_type menu-item-object-page ">
         <a href="202/">Version 2.02</a>
     </li>
@@ -91,7 +91,7 @@
         <a href="105/">Version 1.05</a>
     </li>
      <li class="menu-item menu-item-type-post_type menu-item-object-page ">
-        <a href="202/upgrades/all-versions/">Other Versions</a>
+        <a href="upgrades/all-versions/">Other Versions</a>
     </li>
 </ul>        </nav>
 
@@ -103,45 +103,45 @@
             <!-- Breadcrumb NavXT 4.4.0 -->
 <!--<a title="Go to The IATI Standard." href="http://iatistandard.org" class="home">The IATI Standard</a> &gt; The IATI Activities Standard-->        </div><!--.breadcrumbs -->
         <div id="main">
-        
+
             <div id="home-strapline">
                 <h1>IATI Standard is a technical publishing framework allowing data to be compared. This site gives detail on the standard, how to implement it and provides guidance.</h1>
-                <h2>This website provides reference material for the <a href="202/upgrades/all-versions/">different versions of the IATI Standard</a>. If you do not actively choose a version, the links below will take you the latest 2.02 version.</h2>
+                <h2>This website provides reference material for the <a href="upgrades/all-versions/">different versions of the IATI Standard</a>. If you do not actively choose a version, the links below will take you the latest 2.02 version.</h2>
             </div>
-        
+
 </div><!--#page-content -->
 </div><!--#page -->
 
 <div id="pre-footer">
-    
+
         <div id="home-icon-panels">
             <div class="icon started">
                 <h2><a title="Getting Started" href="introduction/">Getting Started</a></h2>
         <ul>
- <li><a title="Introduction" href="202/introduction/">Introduction</a></li>        
-<li><a title="Key Considerations" href="202/introduction/key-considerations/">Key Considerations</a></li> 
-<li><a title="Preparing your organisation" href="202/guidance/how-to-publish/prepare-your-org/">Preparing your organisation</a></li>
-<li><a title="Tools" href="202/guidance/how-to-publish/select-publishing-tool/">Publishing tools</a></li>            
-<li><a title="Updating IATI data" href="202/guidance/how-to-publish/regular-updates/">Updating IATI data</a></li>
+ <li><a title="Introduction" href="introduction/">Introduction</a></li>
+<li><a title="Key Considerations" href="introduction/key-considerations/">Key Considerations</a></li>
+<li><a title="Preparing your organisation" href="guidance/how-to-publish/prepare-your-org/">Preparing your organisation</a></li>
+<li><a title="Tools" href="guidance/how-to-publish/select-publishing-tool/">Publishing tools</a></li>
+<li><a title="Updating IATI data" href="guidance/how-to-publish/regular-updates/">Updating IATI data</a></li>
         </ul>
             </div>
             <div class="icon detail">
                 <h2><a href="reference/">IATI Reference</a></h2>
         <ul>
-        <li><a title="The IATI Organisation Standard" href="202/organisation-standard/">The Organisation Standard</a></li>
-        <li><a title="The IATI Activity Standard" href="202/activity-standard/">The Activity Standard</a></li>
-        <li><a title="IATI Codelists" href="202/codelists/">Codelists</a></li>
-        <li><a title="IATI Schema" href="202/schema/">Schema</a></li>
-<li><a title="Organisation Identifiers" href="202/organisation-identifiers/">Organisation identifiers</a></li> 
+        <li><a title="The IATI Organisation Standard" href="organisation-standard/">The Organisation Standard</a></li>
+        <li><a title="The IATI Activity Standard" href="activity-standard/">The Activity Standard</a></li>
+        <li><a title="IATI Codelists" href="codelists/">Codelists</a></li>
+        <li><a title="IATI Schema" href="schema/">Schema</a></li>
+<li><a title="Organisation Identifiers" href="organisation-identifiers/">Organisation identifiers</a></li>
         </ul>
         <p>&nbsp;</p>
             </div>
             <div class="icon support">
                 <h2><a title="Community Support" href="http://www.aidtransparency.net/contact/support">Support</a></h2>
         <ul>
-        <li><a title="Upgrading the IATI Standard" href="202/upgrades/">How the Standard is upgraded</a></li>
-<li><a title="Previous versions" href="202/upgrades/all-versions">Previous versions of IATI</a></li>
-        <li><a title="Developers" href="202/developer/">Information for developers</a></li>
+        <li><a title="Upgrading the IATI Standard" href="upgrades/">How the Standard is upgraded</a></li>
+<li><a title="Previous versions" href="upgrades/all-versions">Previous versions of IATI</a></li>
+        <li><a title="Developers" href="developer/">Information for developers</a></li>
 <li><a title="The IATI Datastore" href="http://datastore.iatistandard.org/docs/">The IATI Datastore</a></li>
         </ul>
 
@@ -150,12 +150,12 @@
         <!--        </div>-->
             </div>
         </div><!--#home-icon-panels -->
-    
-    
+
+
     <div id="footer-links">
         <ul>
             <li>
-                <a href="202/sitemap/">Site map</a>
+                <a href="sitemap/">Site map</a>
             </li>
             <li>
                 <a href="http://www.aidtransparency.net/contact/support">Support</a>
@@ -191,7 +191,7 @@
 <script type='text/javascript' src='http://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js?ver=1.8.2'></script>
 <script type='text/javascript' src='_static/library/js/iati.js'></script>
 <script type='text/javascript' src='_static/library/js/common.js'></script>
-    
+
     <script type="text/javascript">
         //<![CDATA[
         var _gaq = _gaq || [];


### PR DESCRIPTION
Removes `202` from URL links. This will continue to redirect to the correct page since the apache configuration redirects URLs with no version number to the most recent version.