### PR TITLE
Fix path to sidemenu icons

### DIFF
--- a/iatistandard/_static/library/js/iati.js
+++ b/iatistandard/_static/library/js/iati.js
@@ -126,7 +126,7 @@
             var $treeContainer = $( treeContainer );
             var $tree = $treeContainer.find('ul').first();
             //Path to image assets
-            var IATIStandard = {"themePath":"http:\/\/iatistandard.org\/wp-content\/themes\/iatistandard"};
+            var IATIStandard = {"themePath":"http:\/\/reference.iatistandard.org\/wp-content\/themes\/iatistandard"};
             var toggleImgPath = IATIStandard.themePath + "/library/images/icons/arrows-theme-accent-right.png";
             var toggleImgPathOpen = IATIStandard.themePath + "/library/images/icons/arrows-theme-accent-down.png";
 


### PR DESCRIPTION
The URL hosting the IATI reference documentation has recently changed to allow for the new IATI website to be hosted at http://iatistandard.org