### PR TITLE
Styling of the first tr child if tbody has withdrawn style applied

### DIFF
--- a/iatistandard/_static/style.css
+++ b/iatistandard/_static/style.css
@@ -308,6 +308,7 @@ dt:hover > a.headerlink {
     text-decoration: underline;
 }
 
+tbody.withdrawn > tr.row-even:first-child,
 tr.withdrawn {
   color: #A0A0A0;
   font-style: italic;


### PR DESCRIPTION
This is a much less intrusive and elegant solution to the problem raised in https://github.com/IATI/IATI-Standard-SSOT/issues/222