### PR TITLE
Replacing aidtransparency.net links with iatistandard.org versions

### DIFF
--- a/iatistandard/_templates/layout.html
+++ b/iatistandard/_templates/layout.html
@@ -1,0 +1,1 @@
+../../../IATI-Websites/iatistandard/_templates/layout_live.html

--- a/iatistandard/_templates/layout_base.html
+++ b/iatistandard/_templates/layout_base.html
@@ -175,7 +175,7 @@
                         <div class="skip-link"><a class="assistive-text" href="#content" title="Skip to primary content">Skip to primary content</a></div>
             <div class="skip-link"><a class="assistive-text" href="#secondary" title="Skip to secondary content">Skip to secondary content</a></div>
             <ul class="iati-family">
-    <li class="transparency"><a href="http://www.aidtransparency.net/">Aid Transparency</a></li>
+    <li class="transparency"><a href="https://iatistandard.org/en/">IATI Site</a></li>
     <li class="standard"><a href="/">IATI Standard</a></li>
     <li class="registry"><a href="http://iatiregistry.org">IATI Data</a></li>
     <li class="community"><a href="http://discuss.iatistandard.org/t/welcome-to-iati-discuss/">IATI Community</a></li>
@@ -278,7 +278,7 @@
         <p>&nbsp;</p>
             </div>
             <div class="icon support">
-                <h2><a title="Community Support" href="http://www.aidtransparency.net/contact/support">Support</a></h2>
+                <h2><a title="Community Support" href="https://iatistandard.org/en/guidance/">Support</a></h2>
         <ul>
         <li><a title="Upgrading the IATI Standard" href="upgrades/">How the Standard is upgraded</a></li>
 <li><a title="Previous versions" href="upgrades/all-versions">Previous versions of IATI</a></li>
@@ -299,7 +299,7 @@
                 <a href="{{ pathto('sitemap') }}">Site map</a>
             </li>
             <li>
-                <a href="http://www.aidtransparency.net/contact/support">Support</a>
+                <a href="https://iatistandard.org/en/guidance/">Support</a>
             </li>
             <li>
                 <a href="https://www.aidtransparency.net/privacy-policy">Privacy policy</a>


### PR DESCRIPTION
Replacing aidtransparency.net links with iatistandard.org versions
Renamed menu item that pointed to Aidtransparency to IATI Site 

Fixes #235