### PR TITLE
Remove aidtransaprency.net menu item. Remove duplicated homepage link

### DIFF
--- a/iatistandard/_static/style.css
+++ b/iatistandard/_static/style.css
@@ -313,3 +313,10 @@ tr.withdrawn {
   color: #A0A0A0;
   font-style: italic;
 }
+
+#main-nav ul.iati-family li.standard a {
+    -moz-border-radius-topleft: 5px;
+    -webkit-border-top-left-radius: 5px;
+    border-top-left-radius: 5px;
+    background-color: #1a206d;
+  }

--- a/iatistandard/_templates/layout_base.html
+++ b/iatistandard/_templates/layout_base.html
@@ -158,8 +158,7 @@
     <div id="page" class="hfeed">
     <header id="header" role="banner">
         <div class="header-wrapper">
-            <a id="logo" href="http://iatistandard.org/iati-standard/"></a>
-            <a id="new-site-link" href="http://iatistandard.org/iati-standard/">Return to main site</a>
+            <a id="logo" href="http://iatistandard.org/"></a>
             <span>
 
             <form role="search" id="searchform" action="/gsearch/">
@@ -175,7 +174,6 @@
                         <div class="skip-link"><a class="assistive-text" href="#content" title="Skip to primary content">Skip to primary content</a></div>
             <div class="skip-link"><a class="assistive-text" href="#secondary" title="Skip to secondary content">Skip to secondary content</a></div>
             <ul class="iati-family">
-    <li class="transparency"><a href="https://iatistandard.org/en/">IATI Site</a></li>
     <li class="standard"><a href="/">IATI Standard</a></li>
     <li class="registry"><a href="http://iatiregistry.org">IATI Data</a></li>
     <li class="community"><a href="http://discuss.iatistandard.org/t/welcome-to-iati-discuss/">IATI Community</a></li>

--- a/iatistandard/root/index.html
+++ b/iatistandard/root/index.html
@@ -44,8 +44,7 @@
     <div id="page" class="hfeed">
     <header id="header" role="banner">
         <div class="header-wrapper">
-            <a id="logo" href="http://iatistandard.org/iati-standard/"></a>
-            <a id="new-site-link" href="http://iatistandard.org/iati-standard/">Return to main site</a>
+            <a id="logo" href="http://iatistandard.org/"></a>
 
             <form role="search" id="searchform" action="/gsearch/">
               <input type="hidden" name="ie" value="UTF-8" />
@@ -60,7 +59,6 @@
                         <div class="skip-link"><a class="assistive-text" href="#content" title="Skip to primary content">Skip to primary content</a></div>
             <div class="skip-link"><a class="assistive-text" href="#secondary" title="Skip to secondary content">Skip to secondary content</a></div>
             <ul class="iati-family">
-    <li class="transparency"><a href="http://www.aidtransparency.net/">Aid Transparency</a></li>
     <li class="standard"><a href="/">IATI Standard</a></li>
     <li class="registry"><a href="http://iatiregistry.org">IATI Data</a></li>
     <li class="community"><a href="http://discuss.iatistandard.org/t/welcome-to-iati-discuss/">IATI Community</a></li>
@@ -138,7 +136,7 @@
         <p>&nbsp;</p>
             </div>
             <div class="icon support">
-                <h2><a title="Community Support" href="http://www.aidtransparency.net/contact/support">Support</a></h2>
+                <h2><a title="Community Support" href="https://iatistandard.org/en/guidance/">Support</a></h2>
         <ul>
         <li><a title="Upgrading the IATI Standard" href="upgrades/">How the Standard is upgraded</a></li>
 <li><a title="Previous versions" href="upgrades/all-versions">Previous versions of IATI</a></li>
@@ -159,7 +157,7 @@
                 <a href="sitemap/">Site map</a>
             </li>
             <li>
-                <a href="http://www.aidtransparency.net/contact/support">Support</a>
+                <a href="https://iatistandard.org/en/guidance/">Support</a>
             </li>
             <li>
                 <a href="https://www.aidtransparency.net/privacy-policy">Privacy policy</a>


### PR DESCRIPTION
This PR removes the AID TRANSPARENCY nav tab because irrelevant and because its color is off brand. Also fixes a couple more aidtransparency.net related links and removes "Back to iati site" link since it's a duplicate of what the logo does anyway.