### PR TITLE
Fix root style.css link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.swp
 *~
+.DS_Store
+.vscode/*
 

--- a/iatistandard/root/index.html
+++ b/iatistandard/root/index.html
@@ -12,7 +12,7 @@
 <script src="_static/html5.js" type="text/javascript"></script>
 <![endif]-->
 
-<link rel='stylesheet' id='main-stylesheet-css'  href='105/_static/style.css' type='text/css' media='all' />
+<link rel='stylesheet' id='main-stylesheet-css'  href='_static/style.css' type='text/css' media='all' />
 <script type='text/javascript' src='_static/library/js/modernizr-2.6.1.min.js'></script>
 <script type='text/javascript' src='_static/library/js/selectivizr.min.js'></script>
 


### PR DESCRIPTION
This makes sure we're not hardcoding a Standard version when linking to the stylesheet in the root `index.html` file

Apache will always defer to the latest version of the Standard and redirect accordingly.
This means we have to start deploying from `latest` to `earliest` rather than the other way around (or at least make sure the deployment of the latest version doesn't fail)