### PR TITLE
Reference images that exist in version control

### DIFF
--- a/iatistandard/_static/library/js/iati.js
+++ b/iatistandard/_static/library/js/iati.js
@@ -126,7 +126,7 @@
             var $treeContainer = $( treeContainer );
             var $tree = $treeContainer.find('ul').first();
             //Path to image assets
-            var IATIStandard = {"themePath":"http:\/\/reference.iatistandard.org\/wp-content\/themes\/iatistandard"};
+            var IATIStandard = {"themePath":"http:\/\/reference.iatistandard.org\/_static"};
             var toggleImgPath = IATIStandard.themePath + "/library/images/icons/arrows-theme-accent-right.png";
             var toggleImgPathOpen = IATIStandard.themePath + "/library/images/icons/arrows-theme-accent-down.png";
 


### PR DESCRIPTION
Similar to #190, but a much simpler solution that will still help mitigate this perennial bug.